### PR TITLE
Add label and dash for no data

### DIFF
--- a/Demo/THCircularProgressView-Demo/THViewController.m
+++ b/Demo/THCircularProgressView-Demo/THViewController.m
@@ -97,8 +97,8 @@
 - (void)timerFired:(NSTimer *)timer
 {
     self.percentage += 0.005;
-    if (self.percentage >= 1) {
-        self.percentage = 0;
+    if (self.percentage > 1.2f) { // short pause on 100
+        self.percentage = 0.0f;
     }
     
     for (THCircularProgressView* progressView in self.examples) {

--- a/Demo/THCircularProgressView-Demo/THViewController.m
+++ b/Demo/THCircularProgressView-Demo/THViewController.m
@@ -52,6 +52,8 @@
                                                                progressBackgroundMode:THProgressBackgroundModeCircumference
                                                               progressBackgroundColor:[UIColor colorWithRed:0.96f green:0.96f blue:0.96f alpha:1.00f]
                                                                            percentage:self.percentage];
+    example2.centerLabel.font = [UIFont boldSystemFontOfSize:radius];
+    example2.isLabelVisible = YES;
     [self.view addSubview:example2];
     [self.examples addObject:example2];
     

--- a/THCircularProgressView/THCircularProgressView.h
+++ b/THCircularProgressView/THCircularProgressView.h
@@ -34,6 +34,7 @@ typedef enum
 @property THProgressMode progressMode;
 @property THProgressBackgroundMode progressBackgroundMode;
 @property (nonatomic) BOOL isLabelVisible;
+@property (nonatomic) BOOL isInvalid;
 
 - (id)initWithCenter:(CGPoint)center
               radius:(CGFloat)radius

--- a/THCircularProgressView/THCircularProgressView.h
+++ b/THCircularProgressView/THCircularProgressView.h
@@ -33,6 +33,7 @@ typedef enum
 @property (nonatomic, strong) UIColor *progressBackgroundColor;
 @property THProgressMode progressMode;
 @property THProgressBackgroundMode progressBackgroundMode;
+@property (nonatomic) BOOL isLabelVisible;
 
 - (id)initWithCenter:(CGPoint)center
               radius:(CGFloat)radius

--- a/THCircularProgressView/THCircularProgressView.m
+++ b/THCircularProgressView/THCircularProgressView.m
@@ -43,10 +43,12 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
         
         self.percentage = percentage;
         
-        self.centerLabel = [[UILabel alloc] initWithFrame:rect];
-        self.centerLabel.center = CGPointMake(radius, radius);
-        self.centerLabel.textAlignment = NSTextAlignmentCenter;
-        self.centerLabel.backgroundColor = [UIColor clearColor];
+        UILabel *label = [[UILabel alloc] initWithFrame:rect];
+        label.center = CGPointMake(radius, radius);
+        label.textAlignment = NSTextAlignmentCenter;
+        label.backgroundColor = [UIColor clearColor];
+        label.adjustsFontSizeToFitWidth = YES;
+        self.centerLabel = label;
         self.isLabelVisible = NO;
         
         [self addSubview:self.centerLabel];

--- a/THCircularProgressView/THCircularProgressView.m
+++ b/THCircularProgressView/THCircularProgressView.m
@@ -136,9 +136,19 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
 
 - (void)setPercentage:(CGFloat)percentage
 {
+    _isInvalid = NO;
     _percentage = fminf(fmax(percentage, 0), 1);
-    _centerLabel.text = [NSString stringWithFormat:@"%.0f", percentage*100.0f];
+    _centerLabel.text = [NSString stringWithFormat:@"%.0f", _percentage*100.0f];
     [self setNeedsDisplay];
+}
+
+- (void) setIsInvalid:(BOOL)invalid;
+{
+    if (invalid) {
+        _percentage = 0.0f;
+        _centerLabel.text = @"–";
+        [self setNeedsDisplay];
+    }
 }
 
 - (void) setIsLabelVisible:(BOOL)isLabelVisible;

--- a/THCircularProgressView/THCircularProgressView.m
+++ b/THCircularProgressView/THCircularProgressView.m
@@ -47,6 +47,7 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
         self.centerLabel.center = CGPointMake(radius, radius);
         self.centerLabel.textAlignment = NSTextAlignmentCenter;
         self.centerLabel.backgroundColor = [UIColor clearColor];
+        self.isLabelVisible = NO;
         
         [self addSubview:self.centerLabel];
     }
@@ -134,7 +135,13 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
 - (void)setPercentage:(CGFloat)percentage
 {
     _percentage = fminf(fmax(percentage, 0), 1);
+    _centerLabel.text = [NSString stringWithFormat:@"%.0f", percentage*100.0f];
     [self setNeedsDisplay];
+}
+
+- (void) setIsLabelVisible:(BOOL)isLabelVisible;
+{
+    self.centerLabel.hidden = !isLabelVisible;
 }
 
 @end


### PR DESCRIPTION
I noticed that there was an unused UILabel, so it's being updated and I added a property to display it.

I also found it useful when there wasn't any data (or invalid data) to show just a dash [–], so that option is also included.

There's a few tweaks to the example so that thes changes can be seen: A label is enabled on one progress indicator and a slight pause at 100.
