### PR TITLE
Add autoresizing

### DIFF
--- a/Demo/THCircularProgressView-Demo/THViewController.m
+++ b/Demo/THCircularProgressView-Demo/THViewController.m
@@ -44,14 +44,11 @@
     [self.examples addObject:example1];
     
     
-    THCircularProgressView *example2 = [[THCircularProgressView alloc] initWithCenter:CGPointMake(width * .75, height * .25)
-                                                                               radius:radius
-                                                                            lineWidth:30.0f
-                                                                         progressMode:THProgressModeFill
-                                                                        progressColor:[UIColor greenColor]
-                                                               progressBackgroundMode:THProgressBackgroundModeCircumference
-                                                              progressBackgroundColor:[UIColor colorWithRed:0.96f green:0.96f blue:0.96f alpha:1.00f]
-                                                                           percentage:self.percentage];
+    THCircularProgressView *example2 = [[THCircularProgressView alloc] initWithFrame:CGRectMake(width/2, example1.frame.origin.y, radius*2, radius*2)];
+    example2.lineWidth = 30.0f;
+    example2.progressColor = [UIColor greenColor];
+    example2.centerLabel.font = [UIFont boldSystemFontOfSize:radius];
+    example2.centerLabelVisible = YES;
     [self.view addSubview:example2];
     [self.examples addObject:example2];
     

--- a/Demo/THCircularProgressView-Demo/THViewController.m
+++ b/Demo/THCircularProgressView-Demo/THViewController.m
@@ -109,7 +109,31 @@
 
 - (BOOL)shouldAutorotate
 {
-    return false;
+    return NO;
+}
+
+- (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;
+{
+    // tap to change size
+    
+    for (THCircularProgressView *view in self.examples) {
+
+        CGFloat newWidth;
+
+        if (view.tag == 2) {
+            newWidth = view.frame.size.width*2;
+            view.tag = 1;
+        } else {
+            newWidth = view.frame.size.width/2;
+            view.tag = 2;
+        }
+        CGRect frame = view.frame;
+        frame.size.width = newWidth;
+        frame.size.height = newWidth;
+        view.frame = frame;
+        
+    }
+    
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Drag the contents of `THCircularProgressView/` into your project.
 `THCircularProgressView` is simply a `UIView` subclass so just instantiate it and add it a view hieararchy. The initializer is:
 
 ```objc
-- (id)initWithCenter:(CGPoint)center
+- (instancetype)initWithCenter:(CGPoint)center
               radius:(CGFloat)radius
            lineWidth:(CGFloat)lineWidth
         progressMode:(THProgressMode)progressMode
@@ -23,8 +23,10 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
           percentage:(CGFloat)percentage
 ```
 
+You can also use the standard `-[UIView initWithFrame:(CGRect)frame]`.
+
 It supports two kinds of progress mode:
-* `THProgressModeFill` - starts empty and gets filled as percentage increases;
+* `THProgressModeFill` - starts empty and gets filled as percentage increases; (default)
 * `THProgressModeDeplete` - starts full and depletes as percentage increases;
 
 There is also a label that can be set to display the number the progress view represents. For example:

--- a/THCircularProgressView/THCircularProgressView.h
+++ b/THCircularProgressView/THCircularProgressView.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSUInteger, THProgressMode) {
 
 @interface THCircularProgressView : UIView
 
+@property (nonatomic) CGFloat radius;
 @property (nonatomic) CGFloat lineWidth;
 @property (nonatomic) CGFloat percentage;
 @property (nonatomic, strong) UILabel *centerLabel;

--- a/THCircularProgressView/THCircularProgressView.h
+++ b/THCircularProgressView/THCircularProgressView.h
@@ -9,18 +9,16 @@
 
 #pragma mark - Enums
 
-typedef enum
-{
+typedef NS_ENUM(NSUInteger, THProgressBackgroundMode) {
     THProgressBackgroundModeNone,
     THProgressBackgroundModeCircle,
     THProgressBackgroundModeCircumference
-} THProgressBackgroundMode;
+};
 
-typedef enum
-{
+typedef NS_ENUM(NSUInteger, THProgressMode) {
     THProgressModeFill,
     THProgressModeDeplete
-} THProgressMode;
+};
 
 #pragma mark - Interface
 
@@ -31,9 +29,9 @@ typedef enum
 @property (nonatomic, strong) UILabel *centerLabel;
 @property (nonatomic, strong) UIColor *progressColor;
 @property (nonatomic, strong) UIColor *progressBackgroundColor;
-@property THProgressMode progressMode;
-@property THProgressBackgroundMode progressBackgroundMode;
 @property (nonatomic) BOOL centerLabelVisible;
+@property (nonatomic) THProgressMode progressMode;
+@property (nonatomic) THProgressBackgroundMode progressBackgroundMode;
 
 - (id)initWithCenter:(CGPoint)center
               radius:(CGFloat)radius

--- a/THCircularProgressView/THCircularProgressView.m
+++ b/THCircularProgressView/THCircularProgressView.m
@@ -9,56 +9,89 @@
 
 #define CGPointCenterPointOfRect(rect) CGPointMake(rect.origin.x + rect.size.width / 2.0f, rect.origin.y + rect.size.height / 2.0f)
 
-@interface THCircularProgressView ()
-
-@property CGPoint center;
-@property CGFloat radius;
-
+@interface THCircularProgressView () {
+    CGFloat oldFrameWidth;
+}
 @end
 
 @implementation THCircularProgressView
 
-- (id)initWithCenter:(CGPoint)center
-              radius:(CGFloat)radius
-           lineWidth:(CGFloat)lineWidth
-        progressMode:(THProgressMode)progressMode
-       progressColor:(UIColor *)progressColor
-progressBackgroundMode:(THProgressBackgroundMode)backgroundMode
-progressBackgroundColor:(UIColor *)progressBackgroundColor
-          percentage:(CGFloat)percentage
+- (instancetype) initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+
+        self.lineWidth = 10.0f;
+        self.progressBackgroundColor = [UIColor colorWithRed:0.96f green:0.96f blue:0.96f alpha:1.00f];
+        self.progressColor = [UIColor redColor];
+        self.progressBackgroundMode = THProgressBackgroundModeCircumference;
+        self.progressMode = THProgressModeFill;
+        
+        self.backgroundColor = [UIColor clearColor];
+        oldFrameWidth = frame.size.width;
+
+        UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, frame.size.height)];
+        label.textAlignment = NSTextAlignmentCenter;
+        label.backgroundColor = [UIColor clearColor];
+        label.adjustsFontSizeToFitWidth = YES;
+        label.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+        self.centerLabel = label;
+        self.centerLabelVisible = NO;
+        
+        self.contentMode = UIViewContentModeRedraw;
+        
+        [self addSubview:self.centerLabel];
+
+    }
+ 
+    return self;
+}
+
+- (instancetype)initWithCenter:(CGPoint)center
+                        radius:(CGFloat)radius
+                     lineWidth:(CGFloat)lineWidth
+                  progressMode:(THProgressMode)progressMode
+                 progressColor:(UIColor *)progressColor
+        progressBackgroundMode:(THProgressBackgroundMode)backgroundMode
+       progressBackgroundColor:(UIColor *)progressBackgroundColor
+                    percentage:(CGFloat)percentage
 {
     CGRect rect = CGRectMake(center.x - radius, center.y - radius, 2 * radius, 2 * radius);
     
-    self = [super initWithFrame:rect];
+    self = [self initWithFrame:rect];
     if (self) {
-        self.backgroundColor = [UIColor clearColor];
- 
-        self.radius = radius;
         self.lineWidth = lineWidth;
-        
         self.progressMode = progressMode;
         self.progressColor = progressColor;
         self.progressBackgroundMode = backgroundMode;
         self.progressBackgroundColor = progressBackgroundColor;
-        
         self.percentage = percentage;
-        
-        self.centerLabel = [[UILabel alloc] initWithFrame:rect];
-        self.centerLabel.center = CGPointMake(radius, radius);
-        self.centerLabel.textAlignment = NSTextAlignmentCenter;
-        self.centerLabel.backgroundColor = [UIColor clearColor];
-        self.centerLabelVisible = NO;
-        
-        [self addSubview:self.centerLabel];
     }
     
     return self;
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    // scale linewidth and font to match new size
+    CGFloat w = self.frame.size.width;
+    CGFloat scale = w/oldFrameWidth;
+    if (scale != 1.0) {
+        _lineWidth *= scale;
+        if (self.centerLabelVisible) {
+            CGFloat pointSize = self.centerLabel.font.pointSize * scale;
+            UIFont *font = [UIFont fontWithName:self.centerLabel.font.fontName size:pointSize];
+            self.centerLabel.font = font;
+        }
+    }
+    oldFrameWidth = w;
+}
+
 - (void)drawRect:(CGRect)rect
 {
     [self drawBackground:rect];
-    [self drawProgress];
+    [self drawProgress:rect];
 }
 
 - (void)drawBackground:(CGRect)rect
@@ -89,9 +122,20 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
     }
 }
 
-- (void)drawProgress
+- (CGFloat) radius
 {
-    CGFloat radiusMinusLineWidth = self.radius - self.lineWidth / 2;
+    return self.frame.size.width/2.0;
+}
+
+- (void) setRadius:(CGFloat)radius
+{
+    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, radius*2.0f, radius*2.0f);
+}
+
+- (void)drawProgress:(CGRect)rect
+{
+    CGFloat radius = [self radius];
+    CGFloat radiusMinusLineWidth = radius - self.lineWidth / 2;
     
     if (self.progressMode == THProgressModeFill && self.percentage > 0) {
         CGFloat startAngle = -M_PI / 2;
@@ -129,6 +173,12 @@ progressBackgroundColor:(UIColor *)progressBackgroundColor
 - (void)setProgressColor:(UIColor *)progressColor
 {
     _progressColor = progressColor;
+    [self setNeedsDisplay];
+}
+
+- (void)setLineWidth:(CGFloat)lineWidth
+{
+    _lineWidth = lineWidth;
     [self setNeedsDisplay];
 }
 


### PR DESCRIPTION
I needed the circular progress to resize (e.g. rotating from landscape to portrait). It seemed much cleaner to use `frame` as the definitive size, instead of `radius` and the center point. (`radius` is now a computed property.) I also reworked the initializer, so that the view can be created with a simple `initWithFrame:`. (I kept backwards compatibility so as not to break others code.)

I also added a few more modern obj-c idioms. `instancetype` and `NS_ENUM`.

The example app is updated, so you can test that everything works. (tap to resize)
