### PR TITLE
Incorrect value displayed when 'percentage' is equal to 0 or 1

### DIFF
--- a/THCircularProgressView.podspec
+++ b/THCircularProgressView.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "THCircularProgressView"
-  s.version      = "0.1.1"
+  s.version      = "0.1.2"
   s.summary      = "A configurable circular progress view."
   s.homepage     = "https://github.com/tiagomnh/THCircularProgressView"
   s.screenshots  = "https://raw.github.com/tiagomnh/THCircularProgressView/master/Screenshot.png"
 
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Tiago Henriques" => "tiagomnh@gmail.com" }
-  s.source       = { :git => "https://github.com/tiagomnh/THCircularProgressView.git", :tag => "0.1.1" }
+  s.source       = { :git => "https://github.com/tiagomnh/THCircularProgressView.git", :tag => "0.1.2" }
 
   s.platform     = :ios, '5.0'
   s.source_files = 'THCircularProgressView/*.{h,m}'

--- a/THCircularProgressView/THCircularProgressView.m
+++ b/THCircularProgressView/THCircularProgressView.m
@@ -146,23 +146,22 @@
     CGFloat radiusMinusLineWidth = radius - self.lineWidth / 2;
     CGFloat percentage = self.percentage;
     
-    if (self.clockwise == NO) {
+    if ((!self.clockwise && percentage < 1.0f) || (self.progressMode == THProgressModeDeplete && percentage == 0.0f)) {
         percentage = 1.0f - percentage;
     }
 
     BOOL clockwise = YES;
-    if ((self.clockwise && self.progressMode == THProgressModeDeplete) ||
-        (self.clockwise == NO && self.progressMode == THProgressModeFill)) {
+    if (percentage < 1.0f && ((self.clockwise && self.progressMode == THProgressModeDeplete) || (!self.clockwise && self.progressMode == THProgressModeFill))) {
         clockwise = NO;
     }
     
     CGFloat startAngle = -M_PI_2;
     CGFloat endAngle = startAngle + percentage * 2 * M_PI;
     
-    if (self.progressMode == THProgressModeFill && percentage > 0) {
+    if (self.progressMode == THProgressModeFill && self.percentage > 0) {
         [self drawProgressArcWithStartAngle:startAngle endAngle:endAngle radius:radiusMinusLineWidth clockwise:clockwise];
     }
-    else if (self.progressMode == THProgressModeDeplete && percentage < 1) {
+    else if (self.progressMode == THProgressModeDeplete && self.percentage < 1) {
         [self drawProgressArcWithStartAngle:startAngle endAngle:endAngle radius:radiusMinusLineWidth clockwise:clockwise];
     }
     


### PR DESCRIPTION
Progress view displays incorrect value when configured in one of the following ways:

| Progress Mode | Clockwise | Percentage |
| --- | --- | --- |
| Deplete | YES | 0 |
| Deplete | NO | 0 |
| Fill | NO | 1 |

**Before change - 0%**
![before 0](https://cloud.githubusercontent.com/assets/103982/5541351/668fa9ea-8ad7-11e4-991f-b881fa617f0c.png)

**Before change - 100%**
![before 100](https://cloud.githubusercontent.com/assets/103982/5541352/6695edc8-8ad7-11e4-8922-7a4bb10da0e3.png)

**After change - 0%**
![after 0](https://cloud.githubusercontent.com/assets/103982/5541356/93fe2410-8ad7-11e4-9343-beea2fc75f4c.png)

**After change - 100%**
![after 100](https://cloud.githubusercontent.com/assets/103982/5541357/94001d1a-8ad7-11e4-94be-f0c2b29b617a.png)
